### PR TITLE
Report missing arg and query name in error

### DIFF
--- a/lib/loadTesting.js
+++ b/lib/loadTesting.js
@@ -10,7 +10,7 @@ const { queryField, mutationField } = require('../utils/schemaDefinition')
 class LoadTesting {
   constructor (schema, args = {}) {
     if (!schema) {
-      throw new Error('The schema is require')
+      throw new Error('The schema is required')
     }
 
     this.schema = schemaParser(schema)

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -19,7 +19,7 @@ describe('Constructor', () => {
     }
 
     expect(error).to.be.an.instanceOf(Error)
-    expect(error.message).to.be.eq('The schema is require')
+    expect(error.message).to.be.eq('The schema is required')
   })
 
   it('Should fail if the schema is null', () => {
@@ -31,7 +31,7 @@ describe('Constructor', () => {
     }
 
     expect(error).to.be.an.instanceOf(Error)
-    expect(error.message).to.be.eq('The schema is require')
+    expect(error.message).to.be.eq('The schema is required')
   })
 
   it('Should initialize constructor', () => {

--- a/test/queryGenerator.js
+++ b/test/queryGenerator.js
@@ -135,7 +135,7 @@ describe('Query generator', () => {
     }
 
     expect(error).to.exist
-    expect(error.message).to.be.eq('All query arguments must be defined')
+    expect(error.message).to.be.eq('Failed to create query arguments for getUserByUsername\nError: All query arguments must be defined - missing id')
   })
 
   it('Should throw an error if a arg is not defined', () => {
@@ -150,7 +150,7 @@ describe('Query generator', () => {
     }
 
     expect(error).to.exist
-    expect(error.message).to.be.eq('All query arguments must be defined')
+    expect(error.message).to.be.eq('Failed to create query arguments for search\nError: No query arguments defined')
   })
 
   it('Should throw an error if the name is missing k6', () => {

--- a/utils/index.js
+++ b/utils/index.js
@@ -10,7 +10,12 @@ function create (schema, query, selectedQueries, args, isMutation) {
 
   let queryHeader
   if (query.arguments.length) {
-    const createdArgs = createQueryArguments(query.arguments, args[query.name])
+    let createdArgs
+    try {
+      createdArgs = createQueryArguments(query.arguments, args[query.name])
+    } catch (err) {
+      throw new Error(`Failed to create query arguments for ${query.name}\n${err}`)
+    }
     queryHeader = `${query.name}(${createdArgs})`
   } else {
     queryHeader = query.name


### PR DESCRIPTION
I updated the exception thrown by `create` & `createQueryArguments` to print the name of the query and the name of the missing argument.