### PR TITLE
Renaming K6 env variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,8 +87,8 @@ export = class LoadTesting {
       stdio: 'inherit',
       shell: true,
       env: {
-        VUS: selectedVus.toString(), // check as string
-        DURATION: selectedDuration,
+        K6_VUS: selectedVus.toString(), // check as string
+        K6_DURATION: selectedDuration,
       },
     })
 


### PR DESCRIPTION
According to documentation (https://k6.io/docs/using-k6/options), it should be `K6_ {param}`. I found this bug while trying to run some tests. Setting `K6_` prefix worked perfectly. 